### PR TITLE
Add support for function identifiers to have a module name

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -103,6 +103,15 @@ func (p *predicateParser) getJoinFunction(op token.Token) (interface{}, error) {
 }
 
 func getIdentifier(node ast.Node) (string, error) {
+	sexpr, ok := node.(*ast.SelectorExpr)
+	if ok {
+		id, ok := sexpr.X.(*ast.Ident)
+		if !ok {
+			return "", fmt.Errorf("expected selector identifier, got: %T", sexpr.X)
+		}
+		return fmt.Sprintf("%s.%s", id.Name, sexpr.Sel.Name), nil
+	}
+
 	id, ok := node.(*ast.Ident)
 	if !ok {
 		return "", fmt.Errorf("expected identifier, got: %T", node)

--- a/parse_test.go
+++ b/parse_test.go
@@ -27,9 +27,10 @@ func (s *PredicateSuite) getParser(c *C) Parser {
 			GE:  numberGE,
 		},
 		Functions: map[string]interface{}{
-			"DivisibleBy": divisibleBy,
-			"Remainder":   numberRemainder,
-			"Len":         stringLength,
+			"DivisibleBy":        divisibleBy,
+			"Remainder":          numberRemainder,
+			"Len":                stringLength,
+			"number.DivisibleBy": divisibleBy,
 		},
 	})
 	c.Assert(err, IsNil)
@@ -41,6 +42,17 @@ func (s *PredicateSuite) TestSinglePredicate(c *C) {
 	p := s.getParser(c)
 
 	pr, err := p.Parse("DivisibleBy(2)")
+	c.Assert(err, IsNil)
+	c.Assert(pr, FitsTypeOf, divisibleBy(2))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(2), Equals, true)
+	c.Assert(fn(3), Equals, false)
+}
+
+func (s *PredicateSuite) TestModulePredicate(c *C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("number.DivisibleBy(2)")
 	c.Assert(err, IsNil)
 	c.Assert(pr, FitsTypeOf, divisibleBy(2))
 	fn := pr.(numberPredicate)


### PR DESCRIPTION
Changes `getIdentifier ` to treat an `ast.SelectorExpr` as a potential `module.Function` style-call, which can then be looked up by `getFunction()`.  This lets you group predicates into "module" like syntax, which can be helpful if you have a group of related predicates (eg, a bunch of math operators)