### PR TITLE
Extend types, add test

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -26,18 +26,18 @@ func (p *predicateParser) Parse(in string) (interface{}, error) {
 		return nil, err
 	}
 
-	return p.parseNode(expr)
+	return p.parse(expr)
 }
 
-func (p *predicateParser) parseNode(node ast.Expr) (interface{}, error) {
-	switch n := node.(type) {
+func (p *predicateParser) parse(expr ast.Expr) (interface{}, error) {
+	switch n := expr.(type) {
 	case *ast.BinaryExpr:
-		x, err := p.parseNode(n.X)
+		x, err := p.parse(n.X)
 		if err != nil {
 			return nil, err
 		}
 
-		y, err := p.parseNode(n.Y)
+		y, err := p.parse(n.Y)
 		if err != nil {
 			return nil, err
 		}
@@ -45,7 +45,7 @@ func (p *predicateParser) parseNode(node ast.Expr) (interface{}, error) {
 		return p.joinPredicates(n.Op, x, y)
 
 	case *ast.ParenExpr:
-		return p.parseNode(n.X)
+		return p.parse(n.X)
 
 	case *ast.UnaryExpr:
 		joinFn, err := p.getJoinFunction(n.Op)
@@ -53,7 +53,7 @@ func (p *predicateParser) parseNode(node ast.Expr) (interface{}, error) {
 			return nil, err
 		}
 
-		node, err := p.parseNode(n.X)
+		node, err := p.parse(n.X)
 		if err != nil {
 			return nil, err
 		}

--- a/parse.go
+++ b/parse.go
@@ -63,7 +63,6 @@ func (p *predicateParser) parseNode(node ast.Expr) (interface{}, error) {
 	default:
 		return p.evaluateExpr(n)
 	}
-
 }
 
 func (p *predicateParser) evaluateArguments(nodes []ast.Expr) ([]interface{}, error) {


### PR DESCRIPTION
#### Description
The `selector`, `index`, and `identifier` expression only worked inside call expressions ie: `equals(some.selector, "banana")`. I couldn't do this `some.selector == "banana"`. It would be nice when user's type a query, they can use this shorter and maybe more recognizable expression as well. 

The `evaluateExpr` method already contained all the logic we needed to handle this, so I added this call when we start parsing.

Example use case:
```
Selector
`first.second.third == "something"`

Index
`first.second["key"] == "something"`

Identifier
`name == "something"`
```